### PR TITLE
Improve UI layout and pressure calc

### DIFF
--- a/pump_controller_settings.json
+++ b/pump_controller_settings.json
@@ -6,6 +6,7 @@
     "fonts": {
         "default": 13,
         "title": 12,
+        "plot_title": 12,
         "editor": 11
     },
     "theme": "litera",


### PR DESCRIPTION
## Summary
- move logging panel below manual controls on the left
- split font settings to support a distinct matplotlib title font
- show faint grid for sequence editor
- replace estimated volume with dynamic pressure calculation

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6855b242e1c0832cbbd705ace56020d0