### PR TITLE
Add shear stress settings and color coding

### DIFF
--- a/pump_controller_settings.json
+++ b/pump_controller_settings.json
@@ -16,5 +16,9 @@
     "plot_pane": 491,
     "autosave_interval_min": 5,
     "tube_inner_diameter_mm": 1.0,
-    "vol_per_rev_ul": 25.0
+    "vol_per_rev_ul": 25.0,
+    "dynamic_viscosity": 0.0070,
+    "tube_coefficient": 0.63,
+    "chamber_type": "µ-Slide VI 0.4",
+    "chamber_p_value": 176.1
 }


### PR DESCRIPTION
## Summary
- widen main menu font
- add chamber coefficient table and defaults
- extend settings dialog with viscosity, tube coefficient and chamber type/p value
- color code forward/backward steps in Sequence Editor
- compute shear stress using new formula
- include new settings defaults in configuration file

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6855cd29b948832cbcb8896e7e98c489